### PR TITLE
Add options and display correct percentage

### DIFF
--- a/XpBar/configuration.lua
+++ b/XpBar/configuration.lua
@@ -20,7 +20,7 @@ local function PresentColorEditor(label, col, col_d)
         if n ~= 1 then
             imgui.SameLine(0, 5)
         end
-        
+
         changedDragInt, i[n] = imgui.DragInt(ids[n], i[n], 1.0, 0, 255, fmt[n])
     end
     imgui.PopItemWidth()
@@ -53,7 +53,7 @@ local function PresentColorEditor(label, col, col_d)
 end
 
 local function ConfigurationWindow(configuration)
-    local this = 
+    local this =
     {
         title = "Experience Bar - Configuration",
         fontScale = 1.0,
@@ -65,12 +65,25 @@ local function ConfigurationWindow(configuration)
 
     local _showWindowSettings = function()
         local success
-        
+
         if imgui.Checkbox("Enable", _configuration.xpEnableWindow) then
             _configuration.xpEnableWindow = not _configuration.xpEnableWindow
             this.changed = true
         end
-        
+
+        if imgui.Checkbox("Hide when menus are open", _configuration.xpHideWhenMenu) then
+            _configuration.xpHideWhenMenu = not _configuration.xpHideWhenMenu
+            this.changed = true
+        end
+        if imgui.Checkbox("Hide when symbol chat/word select is open", _configuration.xpHideWhenSymbolChat) then
+            _configuration.xpHideWhenSymbolChat = not _configuration.xpHideWhenSymbolChat
+            this.changed = true
+        end
+        if imgui.Checkbox("Hide when the menu is unavailable", _configuration.xpHideWhenMenuUnavailable) then
+            _configuration.xpHideWhenMenuUnavailable = not _configuration.xpHideWhenMenuUnavailable
+            this.changed = true
+        end
+
         if imgui.Checkbox("No title bar", _configuration.xpNoTitleBar == "NoTitleBar") then
             if _configuration.xpNoTitleBar == "NoTitleBar" then
                 _configuration.xpNoTitleBar = ""
@@ -135,7 +148,7 @@ local function ConfigurationWindow(configuration)
         if changedDragInt then
             this.changed = true
         end
-        
+
         imgui.SameLine(0, 5)
         changedDragInt, _configuration.xpBarY = imgui.DragInt("##Y", _configuration.xpBarY, 1.0, 0, 0, "Y: %4.0f")
         if changedDragInt then
@@ -174,7 +187,7 @@ local function ConfigurationWindow(configuration)
     return this
 end
 
-return 
+return
 {
     ConfigurationWindow = ConfigurationWindow,
 }

--- a/XpBar/configuration.lua
+++ b/XpBar/configuration.lua
@@ -84,6 +84,11 @@ local function ConfigurationWindow(configuration)
             this.changed = true
         end
 
+        if imgui.Checkbox("Show default instead of error", _configuration.xpShowDefaultNotError) then
+            _configuration.xpShowDefaultNotError = not _configuration.xpShowDefaultNotError
+            this.changed = true
+        end
+
         if imgui.Checkbox("No title bar", _configuration.xpNoTitleBar == "NoTitleBar") then
             if _configuration.xpNoTitleBar == "NoTitleBar" then
                 _configuration.xpNoTitleBar = ""

--- a/XpBar/configuration.lua
+++ b/XpBar/configuration.lua
@@ -120,10 +120,6 @@ local function ConfigurationWindow(configuration)
             this.changed = true
         end
 
-        if imgui.Checkbox("Enable Info", _configuration.xpEnableInfo) then
-            _configuration.xpEnableInfo = not _configuration.xpEnableInfo
-            this.changed = true
-        end
         if imgui.Checkbox("Enable Info Level", _configuration.xpEnableInfoLevel) then
             _configuration.xpEnableInfoLevel = not _configuration.xpEnableInfoLevel
             this.changed = true

--- a/XpBar/init.lua
+++ b/XpBar/init.lua
@@ -65,6 +65,7 @@ if optionsLoaded then
     options.xpHideWhenMenu            = NotNilOrDefault(options.xpHideWhenMenu, true)
     options.xpHideWhenSymbolChat      = NotNilOrDefault(options.xpHideWhenSymbolChat, true)
     options.xpHideWhenMenuUnavailable = NotNilOrDefault(options.xpHideWhenMenuUnavailable, true)
+    options.xpShowDefaultNotError     = NotNilOrDefault(options.xpShowDefaultNotError, false)
     options.xpNoTitleBar              = NotNilOrDefault(options.xpNoTitleBar, "")
     options.xpNoResize                = NotNilOrDefault(options.xpNoResize, "")
     options.xpNoMove                  = NotNilOrDefault(options.xpNoMove, "")
@@ -88,6 +89,7 @@ else
         xpHideWhenMenu = false,
         xpHideWhenSymbolChat = false,
         xpHideWhenMenuUnavailable = false,
+        xpShowDefaultNotError = false,
         xpNoTitleBar = "",
         xpNoResize = "",
         xpNoMove = "",
@@ -118,6 +120,7 @@ local function SaveOptions(options)
         io.write(string.format("    xpHideWhenMenu = %s,\n", tostring(options.xpHideWhenMenu)))
         io.write(string.format("    xpHideWhenSymbolChat = %s,\n", tostring(options.xpHideWhenSymbolChat)))
         io.write(string.format("    xpHideWhenMenuUnavailable = %s,\n", tostring(options.xpHideWhenMenuUnavailable)))
+        io.write(string.format("    xpShowDefaultNotError = %s,\n", tostring(options.xpShowDefaultNotError)))
         io.write(string.format("    xpNoTitleBar = \"%s\",\n", options.xpNoTitleBar))
         io.write(string.format("    xpNoResize = \"%s\",\n", options.xpNoResize))
         io.write(string.format("    xpNoMove = \"%s\",\n", options.xpNoMove))
@@ -174,6 +177,17 @@ local DrawStuff = function()
     local pltData = pso.read_u32(_PLTPointer)
 
     -- Do the thing only if the pointer is not null
+    if (options.xpShowDefaultNotError == false) then
+        if options.xpEnableInfo then
+            if myAddress == 0 then
+                imgui.Text("Player data not found")
+                return
+            elseif pltData == 0 then
+                imgui.Text("PLT data not found")
+                return
+            end
+        end
+    end
     local levelProgress, myLevel, myExp, currLevelExp
     if myAddress == 0 or pltData == 0 then
         if options.xpEnableInfo then

--- a/XpBar/init.lua
+++ b/XpBar/init.lua
@@ -171,6 +171,26 @@ local imguiProgressBar = function(progress, color)
     imgui.PopStyleColor()
 end
 
+
+-- Validate and render  the bar given the pre-determined values
+local renderBarAndText = function(currentLevel, currentExp, expToNextLevel, progressAsFraction)
+
+    imguiProgressBar(progressAsFraction, options.xpBarColor)
+
+    if options.xpEnableInfoLevel then
+        imgui.Text(string.format("Lv    : %i", currentLevel + 1))
+    end
+
+    if options.xpEnableInfoTotal then
+        imgui.Text(string.format("Total : %i", currentExp))
+    end
+
+    if options.xpEnableInfoTNL then
+        imgui.Text(string.format("TNL   : %i", expToNextLevel))
+    end
+end
+
+
 local DrawStuff = function()
     local myIndex = pso.read_u32(_PlayerMyIndex)
     local myAddress = pso.read_u32(_PlayerArray + 4 * myIndex)
@@ -222,17 +242,7 @@ local DrawStuff = function()
         end
     end
 
-    imguiProgressBar(levelProgress, options.xpBarColor)
-
-    if options.xpEnableInfoLevel then
-        imgui.Text(string.format("Lv    : %i", myLevel + 1))
-    end
-    if options.xpEnableInfoTotal then
-        imgui.Text(string.format("Total : %i", myExp))
-    end
-    if options.xpEnableInfoTNL then
-        imgui.Text(string.format("TNL   : %i", currLevelExp))
-    end
+    renderBarAndText(myLevel, myExp, currLevelExp, levelProgress)
 end
 
 -- Drawing

--- a/XpBar/init.lua
+++ b/XpBar/init.lua
@@ -119,18 +119,18 @@ local DrawStuff = function()
     local pltData = pso.read_u32(_PLTPointer)
 
     -- Do the thing only if the pointer is not null
-    if myAddress == 0 then
+    local levelProgress, myLevel, myExp, currLevelExp
+    if myAddress == 0 or pltData == 0 then
         if options.xpEnableInfo then
-            imgui.Text("Player data not found")
-        end
-    elseif pltData == 0 then
-        if options.xpEnableInfo then
-            imgui.Text("PLT data not found")
+            levelProgress = 0
+            myLevel = 0
+            myExp = 0
+            currLevelExp = 50
         end
     else
         local myClass = pso.read_u8(myAddress + 0x961)
-        local myLevel = pso.read_u32(myAddress + 0xE44)
-        local myExp = pso.read_u32(myAddress + 0xE48)
+        myLevel = pso.read_u32(myAddress + 0xE44)
+        myExp = pso.read_u32(myAddress + 0xE48)
 
         local pltLevels = pso.read_u32(pltData)
         local pltClass = pso.read_u32(pltLevels + 4 * myClass)
@@ -146,23 +146,23 @@ local DrawStuff = function()
 
         local thisLevelExp = myExp - thisMaxLevelExp
         local nextLevelexp = nextMaxLevelexp - thisMaxLevelExp
-        local currLevelExp = nextMaxLevelexp - myExp
-        local levelProgress = 1
+        currLevelExp = nextMaxLevelexp - myExp
+        levelProgress = 1
         if nextLevelexp ~= 0 then
             levelProgress = thisLevelExp / nextLevelexp
         end
+    end
 
-        imguiProgressBar(levelProgress, options.xpBarColor)
+    imguiProgressBar(levelProgress, options.xpBarColor)
 
-        if options.xpEnableInfoLevel then
-            imgui.Text(string.format("Lv    : %i", myLevel + 1))
-        end
-        if options.xpEnableInfoTotal then
-            imgui.Text(string.format("Total : %i", myExp))
-        end
-        if options.xpEnableInfoTNL then
-            imgui.Text(string.format("TNL   : %i", currLevelExp))
-        end
+    if options.xpEnableInfoLevel then
+        imgui.Text(string.format("Lv    : %i", myLevel + 1))
+    end
+    if options.xpEnableInfoTotal then
+        imgui.Text(string.format("Total : %i", myExp))
+    end
+    if options.xpEnableInfoTNL then
+        imgui.Text(string.format("TNL   : %i", currLevelExp))
     end
 end
 

--- a/XpBar/init.lua
+++ b/XpBar/init.lua
@@ -218,7 +218,7 @@ local DrawStuff = function()
         currLevelExp = nextMaxLevelexp - myExp
         levelProgress = 1
         if nextLevelexp ~= 0 then
-            levelProgress = thisLevelExp / nextLevelexp
+            levelProgress = math.floor(100 * (thisLevelExp / nextLevelexp)) / 100
         end
     end
 


### PR DESCRIPTION
Add option to display starting stats (e.g. Lv 1, TNL 50, etc) instead of the `Player data not found` error message, as an alternative to the error appearing every time a character is not selected (e.g. in the start screen, character select screen, when changing characters, etc).

Add options to hide xp bar when menus are open, unavailable, or when word select / symbol chat is open.

Display correct percentage by flooring the value, e.g. 99% instead of 100% when close to next level.