### PR TITLE
Set TNL to 0 if current exp is beyond max.

### DIFF
--- a/XpBar/init.lua
+++ b/XpBar/init.lua
@@ -231,7 +231,9 @@ local DrawStuff = function()
 
     local thisLevelExp = charTotalExp - thisMaxLevelExp
     local nextLevelexp = nextMaxLevelexp - thisMaxLevelExp
-    local expToNextLevel = nextMaxLevelexp - charTotalExp
+    -- In case a server patches max exp displayed in the menu to be uncapped, 
+    -- ensure the progress bar shows 100%.
+    local expToNextLevel = math.max(0, nextMaxLevelexp - charTotalExp)
     local progressAsFraction = 1
     if nextLevelexp ~= 0 then
         progressAsFraction = math.floor(100 * (thisLevelExp / nextLevelexp)) / 100


### PR DESCRIPTION
Reason behind this change is an upcoming update on one server will remove the Total Exp cap when viewing it in the menu. This ensures the addon shows 'TNL: 0' instead of a negative number.